### PR TITLE
Update BoardConfigCommon.mk

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -94,6 +94,9 @@ TARGET_HAS_LEGACY_CAMERA_HAL1 := true
 BOARD_GLOBAL_CFLAGS += -DCAMERA_VENDOR_L_COMPAT
 BOARD_USE_SAMSUNG_CAMERAFORMAT_NV21 := true
 
+# Vendor security patch level
+ro.lineage.build.vendor_security_patch=2017-08-01
+
 # RIL
 BOARD_PROVIDES_LIBRIL := true
 BOARD_MOBILEDATA_INTERFACE_NAME := "rmnet0"


### PR DESCRIPTION
* This is needed for Trust, as we don't have a Vendor image that sets a
  valid vendor security patch level.

* Taken from the G800FXXU1CRG3 Factory Image.

Change-Id: I105cc7e464e581683c6784e3aef8f7297b90aea0
See: https://www.sammobile.com/firmwares/galaxy-s5-mini/SM-G800F/DBT/download/G800FXXU1CRG3/227188/